### PR TITLE
修复因找不到类NewsFragment的无参构造函数导致的force close

### DIFF
--- a/source/src/cn/eoe/app/view/NewsFragment.java
+++ b/source/src/cn/eoe/app/view/NewsFragment.java
@@ -49,6 +49,15 @@ public class NewsFragment extends BaseListFragment {
 
 	};
 
+	// add this constructor by King0769, 2013/5/7
+	// in order to solve an exception that "can't instantiate class cn.eoe.app.view.NewsFragment; no empty constructor"
+	// I found it in this case : 1.open eoe program -> 2.change system language -> 3.reopen eoe, can see FC(force close)
+	// I think this bug will happens in many cases.
+	public NewsFragment() {
+		
+	}
+	//--------------------
+	
 	public NewsFragment(Activity c, NewsCategoryListEntity categorys) {
 		this.mActivity = c;
 


### PR DESCRIPTION
测试用例：
1、打开eoe程序。
2、将系统语言改成其他语言，如从中文切换成英文。
3、再次打开eoe程序。
修改改，上述测试用例未能通过，会产生exception，内容为can't instantiate class cn.eoe.app.view.NewsFragment; no empty constructor；在类NewsFragment增加无参构造函数后，此问题未有出现。
相信在很多场景下均会出现此问题，请修复之。
