### PR TITLE
eoecn登陆奔溃bug

### DIFF
--- a/source/src/cn/eoe/app/https/CustomHttpClient.java
+++ b/source/src/cn/eoe/app/https/CustomHttpClient.java
@@ -34,10 +34,12 @@ import org.apache.http.util.EntityUtils;
 import android.content.Context;
 import android.util.Log;
 import cn.eoe.app.R;
+import cn.eoe.app.utils.CommonLog;
+import cn.eoe.app.utils.LogFactory;
 
 public class CustomHttpClient {
 	private static String TAG = "CustomHttpClient";
-
+	private static final CommonLog log = LogFactory.createLog();
 	private static final String CHARSET_UTF8 = HTTP.UTF_8;
 	private static final String CHARSET_GB2312 = "GB2312";
 	private static HttpClient customerHttpClient;
@@ -87,7 +89,8 @@ public class CustomHttpClient {
 	}
 
 	public static String getFromWebByHttpClient(Context context, String url,
-			NameValuePair... nameValuePairs) {
+			NameValuePair... nameValuePairs) throws Exception{
+			log.d("getFromWebByHttpClient url = " + url);
 		try {
 			// http地址
 			// String httpUrl =
@@ -123,10 +126,11 @@ public class CustomHttpClient {
 					R.string.httpError),e);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
+			log.e("IOException ");
 			e.printStackTrace();
 			throw new RuntimeException(context.getResources().getString(
 					R.string.httpError),e);
-		} 
+		} 	
 	}
 
 	/**

--- a/source/src/cn/eoe/app/https/HttpUtils.java
+++ b/source/src/cn/eoe/app/https/HttpUtils.java
@@ -25,16 +25,16 @@ public class HttpUtils {
 	}
 
 	public static String getByHttpClient(Context context,String strUrl,
-			NameValuePair... nameValuePairs) {
+			NameValuePair... nameValuePairs) throws Exception {
 		return CustomHttpClient.getFromWebByHttpClient(context,strUrl, nameValuePairs);
 	}
 
 	// ------------------------------------------------------------------------------------------
 	// 网络连接判断
 	// 判断是否有网络
-	public static boolean isNetworkAvailable(Context context) {
-		return NetWorkHelper.isNetworkAvailable(context);
-	}
+//	public static boolean isNetworkAvailable(Context context) {
+//		return NetWorkHelper.isNetworkAvailable(context);
+//	}
 
 	// 判断mobile网络是否可用
 	public static boolean isMobileDataEnable(Context context) {

--- a/source/src/cn/eoe/app/https/NetWorkHelper.java
+++ b/source/src/cn/eoe/app/https/NetWorkHelper.java
@@ -39,6 +39,26 @@ public class NetWorkHelper {
 		Log.d(LOG_TAG, "network is not available");
 		return false;
 	}
+	
+	public static boolean checkNetState(Context context){
+    	boolean netstate = false;
+		ConnectivityManager connectivity = (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
+		if(connectivity != null)
+		{
+			NetworkInfo[] info = connectivity.getAllNetworkInfo();
+			if (info != null) {
+				for (int i = 0; i < info.length; i++)
+				{
+					if (info[i].getState() == NetworkInfo.State.CONNECTED) 
+					{
+						netstate = true;
+						break;
+					}
+				}
+			}
+		}
+		return netstate;
+    }
 
 	/**
 	 * 判断网络是否为漫游

--- a/source/src/cn/eoe/app/ui/DetailsActivity.java
+++ b/source/src/cn/eoe/app/ui/DetailsActivity.java
@@ -24,6 +24,7 @@ import cn.eoe.app.db.DetailColumn;
 import cn.eoe.app.db.biz.DetailDB;
 import cn.eoe.app.entity.DetailResponseEntity;
 import cn.eoe.app.https.HttpUtils;
+import cn.eoe.app.https.NetWorkHelper;
 import cn.eoe.app.ui.base.BaseActivity;
 import cn.eoe.app.utils.CommonUtil;
 import cn.eoe.app.utils.IntentUtil;
@@ -284,6 +285,10 @@ public class DetailsActivity extends BaseActivity implements OnClickListener {
 			break;
 		}
 		if (url != null) {
+			if (!NetWorkHelper.checkNetState(this)){
+				showLongToast(getResources().getString(R.string.httpisNull));
+				return ;
+			}
 			new LoginAsyncTask().execute(url, v.getId());
 		}
 	}
@@ -306,12 +311,19 @@ public class DetailsActivity extends BaseActivity implements OnClickListener {
 		protected Boolean doInBackground(Object... params) {
 			// TODO Auto-generated method stub
 			id = Integer.parseInt(params[1].toString());
-			if (!HttpUtils.isNetworkAvailable(DetailsActivity.this)) {
-				showLongToast(getResources().getString(R.string.httpisNull));
+//			if (!HttpUtils.isNetworkAvailable(DetailsActivity.this)) {
+//				showLongToast(getResources().getString(R.string.httpisNull));
+//				return false;
+//			}
+			String result;
+			try {
+				result = HttpUtils.getByHttpClient(DetailsActivity.this,
+						params[0].toString());
+			} catch (Exception e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
 				return false;
 			}
-			String result = HttpUtils.getByHttpClient(DetailsActivity.this,
-					params[0].toString());
 			try {
 				JSONObject jsonObj = new JSONObject(result);
 				JSONObject response = jsonObj.getJSONObject("response");

--- a/source/src/cn/eoe/app/ui/DetailsDiscussActivity.java
+++ b/source/src/cn/eoe/app/ui/DetailsDiscussActivity.java
@@ -147,8 +147,15 @@ public class DetailsDiscussActivity extends BaseActivity implements
 		@Override
 		protected List<Map<String, Object>> doInBackground(String... params) {
 			// TODO Auto-generated method stub
-			String result = HttpUtils.getByHttpClient(
-					DetailsDiscussActivity.this, params[0]);
+			String result;
+			try {
+				result = HttpUtils.getByHttpClient(
+						DetailsDiscussActivity.this, params[0]);
+			} catch (Exception e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+				return null;
+			}
 			DetailsDiscussJson DiscussJson = null;
 			try {
 				DiscussJson = mObjectMapper.readValue(result,

--- a/source/src/cn/eoe/app/ui/UserLoginActivity.java
+++ b/source/src/cn/eoe/app/ui/UserLoginActivity.java
@@ -19,6 +19,7 @@ import android.widget.Toast;
 import cn.eoe.app.R;
 import cn.eoe.app.biz.UserDao;
 import cn.eoe.app.https.HttpUtils;
+import cn.eoe.app.https.NetWorkHelper;
 import cn.eoe.app.ui.base.BaseActivity;
 import cn.eoe.app.utils.IntentUtil;
 
@@ -105,6 +106,10 @@ public class UserLoginActivity extends BaseActivity implements OnClickListener {
             Toast.makeText(this, R.string.user_login_enter_key, Toast.LENGTH_SHORT).show();
             return;
         }
+        if (!NetWorkHelper.checkNetState(this)){
+        	showLongToast(getResources().getString(R.string.httpisNull));
+        	return ;
+        }
         new LoginAsyncTask().execute();
     }
     @Override
@@ -135,10 +140,10 @@ public class UserLoginActivity extends BaseActivity implements OnClickListener {
         @Override
         protected Boolean doInBackground(String... params) {
             // TODO Auto-generated method stub
-            if (!HttpUtils.isNetworkAvailable(UserLoginActivity.this)) {
-                showLongToast(getResources().getString(R.string.httpisNull));
-                return false;
-            }
+//            if (!HttpUtils.isNetworkAvailable(UserLoginActivity.this)) {
+//                showLongToast(getResources().getString(R.string.httpisNull));
+//                return false;
+//            }
             try {
                 return mUserDao.mapperJson(editKey.getText().toString()) != null ? true
                         : false;

--- a/source/src/cn/eoe/app/ui/UserLoginUidActivity.java
+++ b/source/src/cn/eoe/app/ui/UserLoginUidActivity.java
@@ -96,8 +96,8 @@ public class UserLoginUidActivity extends BaseActivity implements
 			showShortToast(getResources().getString(R.string.user_pwd));
 			return;
 		}else if (!NetWorkHelper.checkNetState(this)){
-//			showLongToast(getResources().getString(R.string.httpisNull));
-//			return ;
+			showLongToast(getResources().getString(R.string.httpisNull));
+			return ;
 		}
 		String loginUser = String.format(Urls.USER_LOGIN, name, pwd);
 		new LoginAsyncTask().execute(loginUser);

--- a/source/src/cn/eoe/app/ui/UserLoginUidActivity.java
+++ b/source/src/cn/eoe/app/ui/UserLoginUidActivity.java
@@ -16,11 +16,18 @@ import android.widget.LinearLayout;
 import cn.eoe.app.R;
 import cn.eoe.app.config.Urls;
 import cn.eoe.app.https.HttpUtils;
+import cn.eoe.app.https.NetWorkHelper;
 import cn.eoe.app.ui.base.BaseActivity;
+import cn.eoe.app.utils.CommonLog;
 import cn.eoe.app.utils.IntentUtil;
+import cn.eoe.app.utils.LogFactory;
 
 public class UserLoginUidActivity extends BaseActivity implements
 		OnClickListener {
+	
+	private static final CommonLog log = LogFactory.createLog();
+	
+	
 	public static String SharedName = "login";
 	public static String UID = "uid";// 用户名
 	public static String PWD = "pwd";// 密码
@@ -88,6 +95,9 @@ public class UserLoginUidActivity extends BaseActivity implements
 		} else if (TextUtils.isEmpty(pwd)) {
 			showShortToast(getResources().getString(R.string.user_pwd));
 			return;
+		}else if (!NetWorkHelper.checkNetState(this)){
+//			showLongToast(getResources().getString(R.string.httpisNull));
+//			return ;
 		}
 		String loginUser = String.format(Urls.USER_LOGIN, name, pwd);
 		new LoginAsyncTask().execute(loginUser);
@@ -105,12 +115,21 @@ public class UserLoginUidActivity extends BaseActivity implements
 		@Override
 		protected Boolean doInBackground(String... params) {
 			// TODO Auto-generated method stub
-			if (!HttpUtils.isNetworkAvailable(UserLoginUidActivity.this)) {
-				showLongToast(getResources().getString(R.string.httpisNull));
+	
+//			if (!HttpUtils.isNetworkAvailable(UserLoginUidActivity.this)) {
+//				showLongToast(getResources().getString(R.string.httpisNull));
+//				return false;
+//			}
+
+			String result = "";
+			try {
+				result = HttpUtils.getByHttpClient(
+						UserLoginUidActivity.this, params[0]);
+			} catch (Exception e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
 				return false;
 			}
-			String result = HttpUtils.getByHttpClient(
-					UserLoginUidActivity.this, params[0]);
 			try {
 				JSONObject jsonObj = new JSONObject(result);
 				JSONObject response = jsonObj.getJSONObject("response");
@@ -122,6 +141,7 @@ public class UserLoginUidActivity extends BaseActivity implements
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
+			
 			return false;
 		}
 

--- a/source/src/cn/eoe/app/utils/CommonLog.java
+++ b/source/src/cn/eoe/app/utils/CommonLog.java
@@ -1,0 +1,146 @@
+package cn.eoe.app.utils;
+
+import android.util.Log;
+
+public class CommonLog {
+	private String tag = "CommonLog";
+	public static int logLevel = Log.VERBOSE;
+	public static boolean isDebug = true;
+	
+	public CommonLog() { }	
+	
+	public CommonLog(String tag) {
+		this.tag = tag;
+	}
+	
+	public void setTag(String tag) {
+		this.tag = tag;
+	}
+	
+	private String getFunctionName() {
+        StackTraceElement[] sts = Thread.currentThread().getStackTrace();
+        
+        if (sts == null) {
+            return null;
+        }
+        
+        
+        for (StackTraceElement st:sts) {
+            if (st.isNativeMethod()) {
+                continue;
+            }
+
+            if (st.getClassName().equals(Thread.class.getName())) {
+                continue;
+            }
+
+            if (st.getClassName().equals(this.getClass().getName())) {
+                continue;
+            }
+
+            return "["+Thread.currentThread().getId()+": "+st.getFileName()+":"+st.getLineNumber()+"]";
+        }
+        
+        return null;
+	}
+
+	public void info(Object str) {
+	    if (logLevel <= Log.INFO) {	        
+	        String name = getFunctionName();
+	        String ls=(name==null?str.toString():(name+" - "+str));
+	        Log.i(tag, ls);
+	    }
+	}
+	
+	public void i(Object str) {
+		if (isDebug) {
+			info(str);
+		}
+	}
+	
+	public void verbose(Object str) {
+        if (logLevel <= Log.VERBOSE) {
+            String name = getFunctionName();
+            String ls=(name==null?str.toString():(name+" - "+str));
+            Log.v(tag, ls);    
+        }
+	}
+	
+	public void v(Object str) {
+		if (isDebug) {
+			verbose(str);
+		}
+    }
+	
+	public void warn(Object str) {
+	    if (logLevel <= Log.WARN) {
+            String name = getFunctionName();
+            String ls=(name==null?str.toString():(name+" - "+str));
+            Log.w(tag, ls);
+	    }
+	}
+	
+	public void w(Object str) {
+		if (isDebug) {
+			warn(str);
+		}
+    }
+	
+	public void error(Object str) {
+        if (logLevel <= Log.ERROR) {            
+            String name = getFunctionName();
+            String ls=(name==null?str.toString():(name+" - "+str));
+            Log.e(tag, ls);
+        }
+	}
+	
+	public void error(Exception ex) {
+	    if (logLevel <= Log.ERROR) {
+	        StringBuffer sb = new StringBuffer();
+	        String name = getFunctionName();
+	        StackTraceElement[] sts = ex.getStackTrace();
+
+	        if (name != null) {
+                sb.append(name+" - "+ex+"\r\n");
+            } else {
+                sb.append(ex+"\r\n");
+            }
+	        
+	        if (sts != null && sts.length > 0) {
+	            for (StackTraceElement st:sts) {
+	                if (st != null) {
+	                    sb.append("[ "+st.getFileName()+":"+st.getLineNumber()+" ]\r\n");
+	                }
+	            }
+	        }
+
+	        Log.e(tag, sb.toString());
+	    }
+	}
+	
+    public void e(Object str) {
+    	if (isDebug) {
+    		error(str);
+    	}
+    }
+
+    public void e(Exception ex) {
+    	if (isDebug) {
+    		error(ex);
+    	}
+    }
+	
+	public void debug(Object str) {
+        if (logLevel <= Log.DEBUG) {
+            String name = getFunctionName();
+            String ls = (name == null?str.toString():(name+" - "+str));
+            Log.d(tag, ls);
+        }
+	}
+	
+	public void d(Object str) {
+		if (isDebug) {
+			debug(str);
+		}
+    }
+}

--- a/source/src/cn/eoe/app/utils/LogFactory.java
+++ b/source/src/cn/eoe/app/utils/LogFactory.java
@@ -1,0 +1,29 @@
+package cn.eoe.app.utils;
+
+
+public class LogFactory {
+	private static final String TAG = "EOE_CN";
+	private static CommonLog log = null;
+
+	public static CommonLog createLog() {
+		if (log == null) {
+    		log = new CommonLog();
+		}
+		
+		log.setTag(TAG);
+		return log;
+	}
+	
+	public static CommonLog createLog(String tag) {
+		if (log == null) {
+			log = new CommonLog();
+		}
+		
+		if (tag == null || tag.length() < 1) {
+    		log.setTag(TAG);
+		} else {
+			log.setTag(tag);
+		}
+		return log;
+	}
+}


### PR DESCRIPTION
HttpUtils.isNetworkAvailable判断网络方法有误
在NetWorkHelper里新增checkNetState方法判断当前网络状态

在UserLoginUidActivity界面执行登陆时
在执行LoginAsyncTask任务前先判断网络状态
在doInBackground里弹toast提示，这在子线程是不允许的

CustomHttpClient的getFromWebByHttpClient方法必须加上throws Exception强制调用者捕获异常
否则出现异常（如IOException）的时候会导致程序崩溃

友情提示：在LoginAsyncTask任务里，因为网络异常而导致执行失败这种情况
那么在onPostExecute里就不能用用户名密码错误这种提示了

以上这些问题在UserLoginActivity和DetailsActivity里同样存在

最后再加上两个方便打印的工具类，能够显示打印信息所在类以及行数
