### PR TITLE
SplashActivity中延时播放图片 handler处理

### DIFF
--- a/source/src/cn/eoe/app/ui/SplashActivity.java
+++ b/source/src/cn/eoe/app/ui/SplashActivity.java
@@ -13,11 +13,7 @@ import com.umeng.update.UmengUpdateAgent;
 
 public class SplashActivity extends BaseActivity {
 
-	private Handler mHandler = new Handler() {
-		public void handleMessage(android.os.Message msg) {
-			goHome();
-		}
-	};
+	private Handler mHandler = new Handler();
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -35,8 +31,12 @@ public class SplashActivity extends BaseActivity {
 			
 			@Override
 			public void onAnimationEnd(Animation arg0) {
-				mHandler.removeMessages(0);
-				mHandler.sendEmptyMessageDelayed(0, 500);
+				mHandler.postDelayed(new Runnable() {
+					@Override
+					public void run() {
+						goHome();
+					}
+				}, 500);
 			}
 		});
 		UmengUpdateAgent.setUpdateOnlyWifi(false);


### PR DESCRIPTION
感觉对于handler，先清空looper，再发送message，然后handleMessage对消息接收处理，不如直接handler.postDelayed来的直接
