### PR TITLE
修复issue #78 issue #79 issue #84

### DIFF
--- a/source/.classpath
+++ b/source/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="output" path="bin/classes"/>

--- a/source/AndroidManifest.xml
+++ b/source/AndroidManifest.xml
@@ -42,7 +42,7 @@
         </activity>
         <activity
             android:name=".ui.MainActivity"
-            android:hardwareAccelerated="false"
+            android:hardwareAccelerated="true"
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:screenOrientation="portrait" >


### PR DESCRIPTION
### issue #84

对于issue #84 的确是由于没有启动硬件加速引起的。我修改了AndroidMainfest.xml文件使得MainActivity能够使用硬件加速
### issue #78 和issue #79

对于issue #78 和issue #79 我修改了.classpath文件，使得在构建的时候libs文件夹下的jar包会被一同输出。这样就解决了eclipse下运行报错的问题。
